### PR TITLE
Add support for 64bit devices

### DIFF
--- a/FFmpegAndroid/src/androidTest/java/com/github/hiteshsondhi88/libffmpeg/CpuArchHelperTest.java
+++ b/FFmpegAndroid/src/androidTest/java/com/github/hiteshsondhi88/libffmpeg/CpuArchHelperTest.java
@@ -7,17 +7,18 @@ import junit.framework.TestCase;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CpuArchHelperTest extends TestCase {
-
+    
     public void testGetCpuArch() throws Exception {
         CpuArch cpuArch = CpuArchHelper.getCpuArch();
         assertNotNull(cpuArch);
-        if (Build.CPU_ABI.equals(CpuArchHelper.getx86CpuAbi())) {
+        if (Build.CPU_ABI.equals(CpuArchHelper.getx86CpuAbi()) || Build.CPU_ABI.equals(CpuArchHelper.getx86_64CpuAbi())) {
             assertEquals(cpuArch, CpuArch.x86);
         } else if (Build.CPU_ABI.equals(CpuArchHelper.getArmeabiv7CpuAbi())) {
             assertThat(cpuArch == CpuArch.ARMv7 || cpuArch == CpuArch.ARMv7_NEON).isTrue();
-        } else {
+        } else if (Build.CPU_ABI.equals(CpuArchHelper.getArm64CpuAbi())) {
+            assertEquals(cpuArch, CpuArch.ARMv7);
+        }else {
             assertEquals(cpuArch, CpuArch.NONE);
         }
     }
-
 }

--- a/FFmpegAndroid/src/main/java/com/github/hiteshsondhi88/libffmpeg/CpuArchHelper.java
+++ b/FFmpegAndroid/src/main/java/com/github/hiteshsondhi88/libffmpeg/CpuArchHelper.java
@@ -3,10 +3,11 @@ package com.github.hiteshsondhi88.libffmpeg;
 import android.os.Build;
 
 class CpuArchHelper {
-
+    
     static CpuArch getCpuArch() {
-        // check if device is x86
-        if (Build.CPU_ABI.equals(getx86CpuAbi())) {
+        Log.d("Build.CPU_ABI : " + Build.CPU_ABI);
+        // check if device is x86 or x86_64
+        if (Build.CPU_ABI.equals(getx86CpuAbi()) || Build.CPU_ABI.equals(getx86_64CpuAbi())) {
             return CpuArch.x86;
         } else {
             // check if device is armeabi
@@ -21,15 +22,26 @@ class CpuArchHelper {
                     }
                     return CpuArch.ARMv7;
                 }
+                // check if device is arm64 which is supported by ARMV7
+            } else if (Build.CPU_ABI.equals(getArm64CpuAbi())) {
+                return CpuArch.ARMv7;
             }
         }
         return CpuArch.NONE;
     }
-
+    
     static String getx86CpuAbi() {
         return "x86";
     }
-
+    
+    static String getx86_64CpuAbi() {
+        return "x86_64";
+    }
+    
+    static String getArm64CpuAbi() {
+        return "arm64-v8a";
+    }
+    
     static String getArmeabiv7CpuAbi() {
         return "armeabi-v7a";
     }


### PR DESCRIPTION
Add support for 64bit devices 
- x86_64 is supported by x86
- arm64-v8a is supported by armeabi-v7a

You can test it on devices such as LG G4, Galaxy S6 etc.
